### PR TITLE
Patch for the missing sip files

### DIFF
--- a/proposals/00003-fixing-staking-period.md
+++ b/proposals/00003-fixing-staking-period.md
@@ -5,7 +5,7 @@ authors: Ze Huang (ze.huang@piplabs.xyz)
 sponsors: Ramtin Seraj (ramtin.seraj@piplabs.xyz)
 created: 2025-01-04
 type: Standard
-status: Draft
+status: Accepted
 supersedes: 
 superseded-by: 
 extends: 

--- a/proposals/00004-emit-reward-distribution-event.md
+++ b/proposals/00004-emit-reward-distribution-event.md
@@ -1,0 +1,51 @@
+---
+number: '00004'
+title: Emit reward distribution events
+authors: Ze Huang (ze.huang@piplabs.xyz)
+sponsors: Ramtin Seraj (ramtin.seraj@piplabs.xyz)
+created: 2025-01-04
+type: Standard
+status: Draft
+supersedes: 
+superseded-by: 
+extends: 
+---
+
+## Summary
+
+This SIP propose adding a new event type to capture the staking reward 
+distribution. It helps off-chain tools to better track the rewards. 
+
+[forum discussion link](https://forum.story.foundation/t/emit-reward-distribution-events-with-validator-address/46)
+
+## Motivation
+
+Story uses cometbft as the consensus layer(CL) and geth as the execution 
+layer(EL). The two layers communicate through EngineAPI. Users only interact 
+with EL. The staking and unstaking of Story’s native IP token are triggered 
+on EL and the actual logic is handled in CL.
+When an unstaking or reward distribution is triggered, CL needs to send the 
+withdrawn/distributed IP tokens back to EL through EngineAPI.
+
+However, the current EngineAPI interface for withdrawals doesn’t allow for 
+passing in the validator address. Because of this, users on EL side don’t know 
+which validators the withdrawals come from and hence have no ways to calculate 
+rewards APR per validator they stake.
+
+## Proposal
+
+We should emit an event on CL side to capture all withdrawals sent back to EL. 
+The event should include a validator address field so that an indexing solution 
+can pick up this event and calculate the correct reward APR.
+
+### Drawbacks
+
+No drawback knowns
+
+### Alternatives Considered
+
+N/A
+
+### User Impact
+
+N/!

--- a/proposals/00004-emit-reward-distribution-event.md
+++ b/proposals/00004-emit-reward-distribution-event.md
@@ -5,7 +5,7 @@ authors: Ze Huang (ze.huang@piplabs.xyz)
 sponsors: Ramtin Seraj (ramtin.seraj@piplabs.xyz)
 created: 2025-01-04
 type: Standard
-status: Draft
+status: Accepted
 supersedes: 
 superseded-by: 
 extends: 

--- a/proposals/00005-adjusting-staking-reward-boosters.md
+++ b/proposals/00005-adjusting-staking-reward-boosters.md
@@ -1,0 +1,86 @@
+---
+number: '00005'
+title: Updating Staking Rewards Boosters
+authors: Leo Chen (leo@storyprotocol.xyz)
+sponsors: Ramtin Seraj (ramtin.seraj@piplabs.xyz)
+created: 2025-01-04
+type: Standard
+status: Draft
+supersedes: 
+superseded-by: 
+extends: 
+---
+
+## Summary
+
+This SIP propose increasing the reward boosts when community
+ members decides to stake and secure the network for a longer 
+ time windown. 
+
+[forum discussion link](https://forum.story.foundation/t/proposal-update-staking-rewards-boosters/552)
+
+## Motivation
+
+The current staking reward multiplier structure is as follows:
+
+- Flexible staking: 1.0x
+- 90-day fixed staking: 1.051x
+- 360-day fixed staking: 1.16x
+- 540-day fixed staking: 1.34x
+- Locked token staking: 0.5x
+
+These multipliers were initially designed based on the 
+compounding effect of rewards, with a slight bias toward 
+incentivizing long-term staking. However, given the current 
+inflation rate and competitive staking models in the crypto 
+market, the existing structure may not provide sufficient 
+incentives for long-term commitment.
+
+## Proposal
+
+We propose updating the staking reward multipliers to the 
+following structure:
+
+- Flexible staking: 1.0x
+- 90-day fixed staking: 1.1x
+- 360-day fixed staking: 1.5x
+- 540-day fixed staking: 2.0x
+- Locked token staking: 0.5x
+
+This revision aims to significantly enhance incentives for 
+long-term stakers while maintaining a balanced reward 
+distribution. The proposed adjustments provide a more 
+substantial differentiation between short-term and long-term 
+commitments, aligning with industry best practices to attract 
+and retain committed stakeholders.
+
+### Rationale
+
+- Enhanced Long-Term Staking Incentives: The updated 
+multipliers offer a more compelling reward structure for 
+stakers willing to lock their tokens for extended periods, 
+promoting network security and stability.
+
+- Competitive Positioning: The revised staking model ensures 
+that our staking mechanism remains competitive in the 
+evolving crypto landscape, where higher multipliers for 
+long-term staking are becoming more common.
+
+- Inflation Neutrality: This proposal does not alter the 
+overall token emission rate or inflation ratio, ensuring that 
+the total supply dynamics remain unaffected while improving 
+reward efficiency.
+
+### Drawbacks
+
+N/A
+
+### Alternatives Considered
+
+N/A
+
+### User Impact
+
+By implementing these changes, we can foster a stronger, more 
+committed staking community while maintaining long term 
+economic sustainability within the ecosystem.

--- a/proposals/00005-adjusting-staking-reward-boosters.md
+++ b/proposals/00005-adjusting-staking-reward-boosters.md
@@ -5,7 +5,7 @@ authors: Leo Chen (leo@storyprotocol.xyz)
 sponsors: Ramtin Seraj (ramtin.seraj@piplabs.xyz)
 created: 2025-01-04
 type: Standard
-status: Draft
+status: Accepted
 supersedes: 
 superseded-by: 
 extends: 


### PR DESCRIPTION
This PR 
- returns the missing sip files - due to the merge order issue, some files are missing for approved SIPs
- change the status of already approved sips to `accepted`